### PR TITLE
Use Kustomize to simplify config and secret management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 # postgres-statefulset
 This is an example of using Kubernetes StatefulSets to get a Postgres instance running with replication enabled. This also uses the [standard Postgres container](https://github.com/docker-library/postgres). Blog article [here](https://stacksoft.io/blog/postgres-statefulset/)
 
-The work here is based off the official documentation here https://wiki.postgresql.org/wiki/Streaming_Replication
+The work here is based off the [official documentation](https://wiki.postgresql.org/wiki/Streaming_Replication)
 
 ## Configuration
 
-1. Edit `config/secret.yml` with the Postgres database password and the replication password 
-2. Run `kubectl apply -f config/secret.yml` and then `cd config && ./create_configmap.sh`
+Edit `kustomization.yml` with the Postgres database password and the replication password
 
 Note, replication password is used to connect to the master and stream updates to the replica. It just needs to be a random password. 
 
@@ -14,16 +13,7 @@ Note, replication password is used to connect to the master and stream updates t
 
 Running this example is easy!
 
-### Start Master servers
-
-Run `kubectl apply -f statefulset-master.yml` and wait for Master to be running
-
-### Start Master service (IMPORTANT or replica cannot find the master)
-Run `kubectl apply -f service.yml` 
-
-### Start Replica server
-
-Run `kubectl apply -f statefulset-replica.yml` and wait for Replica to be running
+Run `kubectl apply -k .`
 
 If you run `kubectl logs -f postgres-replica-0`, you can see in the logs that it starts replication:
 

--- a/config/create_configmap.sh
+++ b/config/create_configmap.sh
@@ -1,1 +1,0 @@
-kubectl create configmap postgres --from-file=postgres.conf --from-file=master.conf --from-file=replica.conf --from-file=pg_hba.conf --from-file=create-replica-user.sh

--- a/config/secret.yml
+++ b/config/secret.yml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: postgres
-type: Opaque
-stringData:
-  password: master-password
-  replicaPassword: replica-password
-

--- a/kustomization.yml
+++ b/kustomization.yml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+configMapGenerator:
+- name: postgres
+  files:
+  - config/postgres.conf
+  - config/master.conf
+  - config/replica.conf
+  - config/pg_hba.conf
+  - config/create-replica-user.sh
+
+secretGenerator:
+- name: postgres
+  literals:
+  - password=master-password
+  - replicaPassword=replica-password
+
+resources:
+ - statefulset-master.yml
+ - service.yml
+ - statefulset-replica.yml


### PR DESCRIPTION
Use [Kustomize](https://kustomize.io/) to simplify config and secret management by using `configMapGenerator` and `secretGenerator` resources, and shell scripts. Support for Kustomize is native in `kubectl`.

As a bonus you can also deploy this whole example with one command. Ordering and waiting for other resources is not necessary, as this is automatic.

```
kubectl apply -k .
```